### PR TITLE
fix: fail CLI --check when non-canonical classes are found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,18 @@ jobs:
           pnpm --filter @laststance/tailwindcss-canonical-classes-core build
           pnpm --filter @laststance/tailwind-suggest-canonical-classes build
           pnpm --filter prettier-plugin-tailwindcss-canonical-classes build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Prepare environment
+        uses: ./.github/actions/prepare
+
+      - name: Build CLI and run tests
+        run: |
+          pnpm --filter @laststance/tailwindcss-canonical-classes-core build
+          pnpm --filter @laststance/tailwind-suggest-canonical-classes build
+          pnpm --filter @laststance/tailwind-suggest-canonical-classes test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Prepare environment
         uses: ./.github/actions/prepare
@@ -32,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Prepare environment
         uses: ./.github/actions/prepare
@@ -47,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Prepare environment
         uses: ./.github/actions/prepare

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Options:
   --root <dir>             Project root directory (default: cwd)
   --css <file>             Tailwind v4 entry CSS (default: @import "tailwindcss")
   --root-font-size <num>   Root font size in px (default: 16)
-  --check                  Dry run (no writes)
+  --check                  Dry run; exit 1 if non-canonical classes are found
   --dry-run                Alias for --check
   --verbose                Print per-file results
   --help                   Show help
@@ -63,7 +63,7 @@ Options:
 | Code | Meaning |
 |------|---------|
 | `0` | Success — command completed successfully (including `--help` when a target is present) |
-| `1` | Failure — missing targets, no matching files, missing Tailwind v4 design system, or other errors |
+| `1` | Failure — missing targets, no matching files, missing Tailwind v4, file errors, or `--check` found non-canonical classes |
 
 ### Prettier Plugin (Recommended)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,7 +22,7 @@ npm install -D @laststance/tailwind-suggest-canonical-classes tailwindcss
 # Fix files in place
 tailwind-suggest-canonical-classes "src/**/*.{tsx,jsx,html}"
 
-# Dry run (no writes)
+# Dry run (no writes); exits 1 if non-canonical classes are found
 tailwind-suggest-canonical-classes "src/**/*.tsx" --check
 
 # Verbose output
@@ -36,7 +36,7 @@ tailwind-suggest-canonical-classes "src/**/*.tsx" --verbose
 | `--root <dir>` | | `cwd` | Project root directory |
 | `--css <file>` | | `@import "tailwindcss"` | Tailwind v4 entry CSS file path |
 | `--root-font-size <num>` | | `16` | Root font size in px for rem-based canonicalization |
-| `--check` | | | Dry run mode (no file writes) |
+| `--check` | | | Dry run; exit 1 if non-canonical classes are found |
 | `--dry-run` | | | Alias for `--check` |
 | `--verbose` | `-v` | | Print per-file results |
 | `--help` | `-h` | | Show help |

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --test --experimental-strip-types test/resolve-cli-exit-code.test.ts"
   },
   "keywords": [
     "tailwindcss",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --test --experimental-strip-types test/resolve-cli-exit-code.test.ts"
+    "test": "node --test test/resolve-cli-exit-code.test.js"
   },
   "keywords": [
     "tailwindcss",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,10 +8,10 @@ import {
   canonicalizeDocument,
   isSupportedExtension,
 } from '@laststance/tailwindcss-canonical-classes-core'
+import { EXIT_FAILURE, EXIT_SUCCESS } from './constants.js'
+import { resolveCliExitCode } from './utils/resolve-cli-exit-code.js'
 
 const CLI_NAME = 'tailwind-suggest-canonical-classes'
-const EXIT_SUCCESS = 0
-const EXIT_FAILURE = 1
 
 type WriteMode = 'write' | 'check'
 
@@ -85,9 +85,13 @@ async function main(): Promise<void> {
     `Done. changed=${changed} unchanged=${unchanged} skipped=${skipped} errors=${errors}`,
   )
 
-  if (errors > 0) {
-    process.exit(EXIT_FAILURE)
-  }
+  process.exit(
+    resolveCliExitCode({
+      writeMode: args.writeMode,
+      changed,
+      errors,
+    }),
+  )
 }
 
 /**
@@ -154,7 +158,7 @@ function buildUsage(): string {
     '  --root <dir>             Project root directory (default: cwd)',
     '  --css <file>             Tailwind v4 entry CSS (default: @import "tailwindcss")',
     '  --root-font-size <num>   Root font size in px (default: 16)',
-    '  --check                  Dry run (no writes)',
+    '  --check                  Dry run; exit 1 if non-canonical classes are found',
     '  --dry-run                Alias for --check',
     '  --verbose                Print per-file results',
     '  --help                   Show this help',

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -1,0 +1,5 @@
+/** Process exit code for a successful CLI run. */
+export const EXIT_SUCCESS = 0
+
+/** Process exit code for a failed CLI run, including CI `--check` failures. */
+export const EXIT_FAILURE = 1

--- a/packages/cli/src/utils/resolve-cli-exit-code.ts
+++ b/packages/cli/src/utils/resolve-cli-exit-code.ts
@@ -1,0 +1,32 @@
+import { EXIT_FAILURE, EXIT_SUCCESS } from '../constants.js'
+
+type CliWriteMode = 'write' | 'check'
+
+type ResolveCliExitCodeInput = {
+  writeMode: CliWriteMode
+  changed: number
+  errors: number
+}
+
+/**
+ * Choose the process exit code after every target file has been processed.
+ * `--check` / `--dry-run` must fail when any file still contains non-canonical
+ * classes so CI can treat the command like `prettier --check`.
+ * Called from `main()` once file results have been summarized.
+ * @returns `0` when the run succeeded, `1` when the process should fail
+ * @example
+ * resolveCliExitCode({ writeMode: 'check', changed: 1, errors: 0 }) // 1
+ */
+export function resolveCliExitCode(input: ResolveCliExitCodeInput): number {
+  // File-read/parse failures always fail the run.
+  if (input.errors > 0) {
+    return EXIT_FAILURE
+  }
+
+  // Check mode reports files that would be rewritten; CI must see that as failure.
+  if (input.writeMode === 'check' && input.changed > 0) {
+    return EXIT_FAILURE
+  }
+
+  return EXIT_SUCCESS
+}

--- a/packages/cli/test/resolve-cli-exit-code.test.js
+++ b/packages/cli/test/resolve-cli-exit-code.test.js
@@ -2,12 +2,10 @@ import assert from 'node:assert/strict'
 import { describe, it } from 'node:test'
 import { resolveCliExitCode } from '../dist/utils/resolve-cli-exit-code.js'
 
-type ResolveCliExitCodeInput = Parameters<typeof resolveCliExitCode>[0]
-
 describe('resolveCliExitCode', () => {
   it('exits with 1 when --check finds files that would be rewritten', () => {
     // Arrange
-    const input: ResolveCliExitCodeInput = { writeMode: 'check', changed: 1, errors: 0 }
+    const input = { writeMode: 'check', changed: 1, errors: 0 }
 
     // Act
     const exitCode = resolveCliExitCode(input)
@@ -18,7 +16,7 @@ describe('resolveCliExitCode', () => {
 
   it('exits with 0 when --check finds no files that would be rewritten', () => {
     // Arrange
-    const input: ResolveCliExitCodeInput = { writeMode: 'check', changed: 0, errors: 0 }
+    const input = { writeMode: 'check', changed: 0, errors: 0 }
 
     // Act
     const exitCode = resolveCliExitCode(input)
@@ -29,7 +27,7 @@ describe('resolveCliExitCode', () => {
 
   it('exits with 0 when write mode rewrites files successfully', () => {
     // Arrange
-    const input: ResolveCliExitCodeInput = { writeMode: 'write', changed: 2, errors: 0 }
+    const input = { writeMode: 'write', changed: 2, errors: 0 }
 
     // Act
     const exitCode = resolveCliExitCode(input)
@@ -40,7 +38,7 @@ describe('resolveCliExitCode', () => {
 
   it('exits with 1 when any file processing error occurred', () => {
     // Arrange
-    const input: ResolveCliExitCodeInput = { writeMode: 'check', changed: 0, errors: 1 }
+    const input = { writeMode: 'check', changed: 0, errors: 1 }
 
     // Act
     const exitCode = resolveCliExitCode(input)

--- a/packages/cli/test/resolve-cli-exit-code.test.ts
+++ b/packages/cli/test/resolve-cli-exit-code.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { resolveCliExitCode } from '../dist/utils/resolve-cli-exit-code.js'
+
+type ResolveCliExitCodeInput = Parameters<typeof resolveCliExitCode>[0]
+
+describe('resolveCliExitCode', () => {
+  it('exits with 1 when --check finds files that would be rewritten', () => {
+    // Arrange
+    const input: ResolveCliExitCodeInput = { writeMode: 'check', changed: 1, errors: 0 }
+
+    // Act
+    const exitCode = resolveCliExitCode(input)
+
+    // Assert
+    assert.equal(exitCode, 1)
+  })
+
+  it('exits with 0 when --check finds no files that would be rewritten', () => {
+    // Arrange
+    const input: ResolveCliExitCodeInput = { writeMode: 'check', changed: 0, errors: 0 }
+
+    // Act
+    const exitCode = resolveCliExitCode(input)
+
+    // Assert
+    assert.equal(exitCode, 0)
+  })
+
+  it('exits with 0 when write mode rewrites files successfully', () => {
+    // Arrange
+    const input: ResolveCliExitCodeInput = { writeMode: 'write', changed: 2, errors: 0 }
+
+    // Act
+    const exitCode = resolveCliExitCode(input)
+
+    // Assert
+    assert.equal(exitCode, 0)
+  })
+
+  it('exits with 1 when any file processing error occurred', () => {
+    // Arrange
+    const input: ResolveCliExitCodeInput = { writeMode: 'check', changed: 0, errors: 1 }
+
+    // Act
+    const exitCode = resolveCliExitCode(input)
+
+    // Assert
+    assert.equal(exitCode, 1)
+  })
+})


### PR DESCRIPTION
## Summary
- Make `--check` / `--dry-run` exit `1` when any file would be rewritten, so CI can gate on non-canonical classes the same way as `prettier --check`.
- Extract `resolveCliExitCode` and cover the success/failure cases with `node:test`.
- Document the exit-code contract and run CLI tests in CI.

Fixes #2

## Test plan
- [x] `pnpm --filter @laststance/tailwind-suggest-canonical-classes test` passes
- [x] CLI `--check` on a file with `mt-[16px]` exits `1`
- [x] CLI `--check` on a file with `mt-4` exits `0`
- [x] CLI write mode still exits `0` after rewriting a non-canonical class
- [ ] CI checks on this PR are green
- [ ] CodeRabbit review completes without unresolved findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The CLI now returns clear success or failure statuses based on processing errors, changed files, and check-mode results.
  * Check mode exits with status 1 when non-canonical classes are detected.

* **Documentation**
  * Clarified CLI check-mode behavior and exit codes.

* **Tests**
  * Added coverage for CLI exit outcomes across check mode, write mode, and error scenarios.

* **Chores**
  * Expanded automated testing in CI for core and suggestion packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->